### PR TITLE
Update to laravel 12

### DIFF
--- a/.github/workflows/tests-base.yml
+++ b/.github/workflows/tests-base.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         php: [ 8.3 ]
-        laravel: [ 11.* ]
+        laravel: [ 11.*, 12.* ]
         dependency-version: [ prefer-lowest, prefer-stable ]
 
     name: "P:${{ matrix.php }}, L:${{ matrix.laravel }}, V: ${{ matrix.dependency-version }}"

--- a/.github/workflows/tests-vue.yml
+++ b/.github/workflows/tests-vue.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         php: [ 8.3 ]
-        laravel: [ 11.* ]
+        laravel: [ 11.*, 12.* ]
         dependency-version: [ prefer-stable ]
 
     name: "P:${{ matrix.php }}, L:${{ matrix.laravel }}, V: ${{ matrix.dependency-version }}"

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^10.5|^11",
-        "orchestra/testbench": "^9.5",
+        "orchestra/testbench": "^9.5|v10.1.0",
         "nikic/php-parser": "^5.4"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -11,10 +11,10 @@
     ],
     "require": {
         "php": "^8.2",
-        "illuminate/support": "^11",
-        "illuminate/console": "^11",
-        "illuminate/process": "^11",
-        "laravel/framework": "^11",
+        "illuminate/support": "^11|^12",
+        "illuminate/console": "^11|^12",
+        "illuminate/process": "^11|^12",
+        "laravel/framework": "^11|^12",
         "inertiajs/inertia-laravel": "^2.0"
     },
     "require-dev": {


### PR DESCRIPTION
## Issue
At the moment you get an `Your requirements could not be resolved to an installable set of packages.` Error if you try to install fusion in a new Laravel install. This is because Laravel 12 isn't allowed in the composer.json as dependency.

## Solution
Update the composer Dependencies to also allow Laravel 12. 

I also added the new test cases to the GithubActions. 