### PR TITLE
Fix vite.config.ts throwing error because vite.config.js is not found

### DIFF
--- a/src/Console/Actions/AddViteConfig.php
+++ b/src/Console/Actions/AddViteConfig.php
@@ -84,7 +84,7 @@ class AddViteConfig
         // Add fusion import after the last import
         return str_replace(
             $lastImport,
-            $lastImport."\nimport fusion from '@fusion/vue/vite';",
+            $lastImport . "\nimport fusion from '@fusion/vue/vite';",
             $content
         );
     }
@@ -99,10 +99,10 @@ class AddViteConfig
         // Get the current indentation level
         preg_match('/^(\s+)plugins:/m', $content, $indentMatches);
         $baseIndent = $indentMatches[1] ?? '  ';
-        $pluginIndent = $baseIndent.'  ';
+        $pluginIndent = $baseIndent . '  ';
 
         // Format the fusion plugin with proper indentation
-        $fusionPlugin = "\n".$pluginIndent.'fusion(),';
+        $fusionPlugin = "\n" . $pluginIndent . 'fusion(),';
 
         // Find the position right after the opening bracket of the plugins array
         $pluginsStart = strpos($content, 'plugins: [') + strlen('plugins: [');
@@ -115,7 +115,7 @@ class AddViteConfig
 
         // Ensure consistent spacing around brackets
         $content = preg_replace('/\[\s+\n/', "[\n", $content);
-        $content = preg_replace('/,\s*\n\s*\]/', "\n".$baseIndent.']', $content);
+        $content = preg_replace('/,\s*\n\s*\]/', "\n" . $baseIndent . ']', $content);
 
         return $content;
     }
@@ -129,6 +129,7 @@ class AddViteConfig
         // Check if vite.config.[js/ts] exists
         if (!$this->configName) {
             $this->error('[Vite] vite.config.[js/ts] not found in the project root!');
+
             return false;
         }
 

--- a/src/Console/Actions/AddViteConfig.php
+++ b/src/Console/Actions/AddViteConfig.php
@@ -15,6 +15,8 @@ class AddViteConfig
 {
     use InteractsWithIO;
 
+    protected ?string $configName;
+
     public function __construct(InputInterface $input, OutputInterface $output)
     {
         $this->input = $input;
@@ -23,14 +25,11 @@ class AddViteConfig
 
     public function handle()
     {
-        $configPath = base_path('vite.config.js');
-
-        // Check if vite.config.js exists
-        if (!File::exists($configPath)) {
-            $this->error('[Vite] vite.config.js not found in the project root!');
-
+        if (!$this->findViteConfig()) {
             return 1;
         }
+
+        $configPath = base_path($this->configName);
 
         $content = File::get($configPath);
 
@@ -42,7 +41,7 @@ class AddViteConfig
         }
 
         // Create backup only if we need to make changes
-        $backupPath = base_path('vite.config.js.backup');
+        $backupPath = base_path("{$this->configName}.backup");
         File::copy($configPath, $backupPath);
 
         try {
@@ -55,8 +54,8 @@ class AddViteConfig
             // Write modified content back to file
             File::put($configPath, $content);
 
-            $this->info('[Vite] Successfully added Fusion plugin to vite.config.js');
-            $this->info('[Vite] Backup created at vite.config.js.backup');
+            $this->info("[Vite] Successfully added Fusion plugin to {$this->configName}");
+            $this->info("[Vite] Backup created at {$this->configName}.backup");
 
             return 0;
         } catch (\Exception $e) {
@@ -77,7 +76,7 @@ class AddViteConfig
         preg_match_all('/^import .+$/m', $content, $matches);
 
         if (empty($matches[0])) {
-            throw new \Exception('Could not find import statements in vite.config.js');
+            throw new \Exception("Could not find import statements in {$this->configName}");
         }
 
         $lastImport = end($matches[0]);
@@ -85,7 +84,7 @@ class AddViteConfig
         // Add fusion import after the last import
         return str_replace(
             $lastImport,
-            $lastImport . "\nimport fusion from '@fusion/vue/vite';",
+            $lastImport."\nimport fusion from '@fusion/vue/vite';",
             $content
         );
     }
@@ -94,16 +93,16 @@ class AddViteConfig
     {
         // Extract the plugins array content
         if (!preg_match('/plugins:\s*\[(.*?)\]/s', $content, $matches)) {
-            throw new \Exception('Could not find plugins array in vite.config.js');
+            throw new \Exception("Could not find plugins array in {$this->configName}");
         }
 
         // Get the current indentation level
         preg_match('/^(\s+)plugins:/m', $content, $indentMatches);
         $baseIndent = $indentMatches[1] ?? '  ';
-        $pluginIndent = $baseIndent . '  ';
+        $pluginIndent = $baseIndent.'  ';
 
         // Format the fusion plugin with proper indentation
-        $fusionPlugin = "\n" . $pluginIndent . 'fusion(),';
+        $fusionPlugin = "\n".$pluginIndent.'fusion(),';
 
         // Find the position right after the opening bracket of the plugins array
         $pluginsStart = strpos($content, 'plugins: [') + strlen('plugins: [');
@@ -116,8 +115,23 @@ class AddViteConfig
 
         // Ensure consistent spacing around brackets
         $content = preg_replace('/\[\s+\n/', "[\n", $content);
-        $content = preg_replace('/,\s*\n\s*\]/', "\n" . $baseIndent . ']', $content);
+        $content = preg_replace('/,\s*\n\s*\]/', "\n".$baseIndent.']', $content);
 
         return $content;
+    }
+
+    private function findViteConfig(): bool
+    {
+        $this->configName = collect(['vite.config.js', 'vite.config.ts'])
+            ->filter(fn(string $configName) => File::exists(base_path($configName)))
+            ->first();
+
+        // Check if vite.config.[js/ts] exists
+        if (!$this->configName) {
+            $this->error('[Vite] vite.config.[js/ts] not found in the project root!');
+            return false;
+        }
+
+        return true;
     }
 }

--- a/tests/Unit/Console/Actions/AddViteConfigTest.php
+++ b/tests/Unit/Console/Actions/AddViteConfigTest.php
@@ -11,26 +11,25 @@ use Symfony\Component\Console\Output\NullOutput;
 
 class AddViteConfigTest extends Base
 {
-
     private AddViteConfig $action;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
-        app()->setBasePath(__DIR__.'/__test');
+        app()->setBasePath(__DIR__ . '/__test');
 
-        File::ensureDirectoryExists(__DIR__.'/__test');
+        File::ensureDirectoryExists(__DIR__ . '/__test');
         File::put(base_path('vite.config.js'), $this->viteConfigOriginalString());
 
         $this->action = app()->make(AddViteConfig::class, [
             'input' => new ArrayInput([]),
-            'output' => new NullOutput(),
+            'output' => new NullOutput,
         ]);
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
-        File::deleteDirectory(__DIR__.'/__test');
+        File::deleteDirectory(__DIR__ . '/__test');
         parent::tearDown();
     }
 
@@ -139,5 +138,4 @@ export default defineConfig({
 });
 ";
     }
-
 }

--- a/tests/Unit/Console/Actions/AddViteConfigTest.php
+++ b/tests/Unit/Console/Actions/AddViteConfigTest.php
@@ -1,0 +1,143 @@
+<?php
+
+namespace Fusion\Tests\Unit\Console\Actions;
+
+use Fusion\Console\Actions\AddViteConfig;
+use Fusion\Tests\Unit\Base;
+use Illuminate\Support\Facades\File;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\NullOutput;
+
+class AddViteConfigTest extends Base
+{
+
+    private AddViteConfig $action;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        app()->setBasePath(__DIR__.'/__test');
+
+        File::ensureDirectoryExists(__DIR__.'/__test');
+        File::put(base_path('vite.config.js'), $this->viteConfigOriginalString());
+
+        $this->action = app()->make(AddViteConfig::class, [
+            'input' => new ArrayInput([]),
+            'output' => new NullOutput(),
+        ]);
+    }
+
+    public function tearDown(): void
+    {
+        File::deleteDirectory(__DIR__.'/__test');
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function can_update_vite_config()
+    {
+        $status = $this->action->handle();
+
+        $this->assertNotEquals(1, $status);
+        $this->assertEquals(File::get(base_path('vite.config.js')), $this->viteConfigExpectedString());
+        $this->assertEquals(File::get(base_path('vite.config.js.backup')), $this->viteConfigOriginalString());
+    }
+
+    #[Test]
+    public function can_update_vite_config_as_typescript_file()
+    {
+        File::move(base_path('vite.config.js'), base_path('vite.config.ts'));
+
+        $status = $this->action->handle();
+
+        $this->assertNotEquals(1, $status);
+        $this->assertEquals(File::get(base_path('vite.config.ts')), $this->viteConfigExpectedString());
+        $this->assertEquals(File::get(base_path('vite.config.ts.backup')), $this->viteConfigOriginalString());
+    }
+
+    private function viteConfigExpectedString(): string
+    {
+        return "import vue from '@vitejs/plugin-vue';
+import autoprefixer from 'autoprefixer';
+import laravel from 'laravel-vite-plugin';
+import path from 'path';
+import tailwindcss from 'tailwindcss';
+import { resolve } from 'node:path';
+import { defineConfig } from 'vite';
+import fusion from '@fusion/vue/vite';
+
+export default defineConfig({
+    plugins: [
+      fusion(),
+        laravel({
+            input: ['resources/js/app.ts'],
+            ssr: 'resources/js/ssr.ts',
+            refresh: true,
+        }),
+        vue({
+            template: {
+                transformAssetUrls: {
+                    base: null,
+                    includeAbsolute: false,
+                },
+            },
+        })
+    ],
+    resolve: {
+        alias: {
+            '@': path.resolve(__dirname, './resources/js'),
+            'ziggy-js': resolve(__dirname, 'vendor/tightenco/ziggy'),
+        },
+    },
+    css: {
+        postcss: {
+            plugins: [tailwindcss, autoprefixer],
+        },
+    },
+});
+";
+    }
+
+    private function viteConfigOriginalString(): string
+    {
+        return "import vue from '@vitejs/plugin-vue';
+import autoprefixer from 'autoprefixer';
+import laravel from 'laravel-vite-plugin';
+import path from 'path';
+import tailwindcss from 'tailwindcss';
+import { resolve } from 'node:path';
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+    plugins: [
+        laravel({
+            input: ['resources/js/app.ts'],
+            ssr: 'resources/js/ssr.ts',
+            refresh: true,
+        }),
+        vue({
+            template: {
+                transformAssetUrls: {
+                    base: null,
+                    includeAbsolute: false,
+                },
+            },
+        }),
+    ],
+    resolve: {
+        alias: {
+            '@': path.resolve(__dirname, './resources/js'),
+            'ziggy-js': resolve(__dirname, 'vendor/tightenco/ziggy'),
+        },
+    },
+    css: {
+        postcss: {
+            plugins: [tailwindcss, autoprefixer],
+        },
+    },
+});
+";
+    }
+
+}


### PR DESCRIPTION
## Issue
The install command searches for a `vite.config.js` but with a new Laravel install comes a `vite.config.ts`. This Throws an error and the config is not updated. 

## Solution
I updated the install command to check if an `.js` or `.ts` config exists and updated the existing config. 

## Test
I saw that there are no Tests for the Commands, or i didn't found them. I added one Test Class for the AddViteConfig Console Action but limited my self to only testing the happy path and my new Addition to keep the PR small. The Test it self is a bit hacky but should work. I would be happy if someone has a more elegant Solution.  