### PR TITLE
Fix app.ts throwing error because app.js is not found

### DIFF
--- a/src/Console/Actions/AddVuePlugin.php
+++ b/src/Console/Actions/AddVuePlugin.php
@@ -84,7 +84,7 @@ class AddVuePlugin
         // Add fusion import after the last import
         return str_replace(
             $lastImport,
-            $lastImport."\nimport fusion from '@fusion/vue/vue';",
+            $lastImport . "\nimport fusion from '@fusion/vue/vue';",
             $content
         );
     }
@@ -110,7 +110,7 @@ class AddVuePlugin
         $baseIndent = $indentMatches[1] ?? '    ';
 
         // Add .use(fusion) with proper indentation
-        $modifiedChain = $beforeMount."\n".$baseIndent.'.use(fusion)'."\n".$baseIndent.'.mount(el);';
+        $modifiedChain = $beforeMount . "\n" . $baseIndent . '.use(fusion)' . "\n" . $baseIndent . '.mount(el);';
 
         return str_replace($createAppChain, $modifiedChain, $content);
     }

--- a/src/Console/Actions/AddVuePlugin.php
+++ b/src/Console/Actions/AddVuePlugin.php
@@ -25,7 +25,6 @@ class AddVuePlugin
 
     public function handle()
     {
-
         if (!$this->findAppEntry()) {
             return 1;
         }
@@ -85,7 +84,7 @@ class AddVuePlugin
         // Add fusion import after the last import
         return str_replace(
             $lastImport,
-            $lastImport . "\nimport fusion from '@fusion/vue/vue';",
+            $lastImport."\nimport fusion from '@fusion/vue/vue';",
             $content
         );
     }
@@ -93,7 +92,7 @@ class AddVuePlugin
     private function addFusionPlugin(string $content): string
     {
         // Find the createApp chain
-        if (!preg_match('/createApp.*?mount\(el\);/s', $content, $matches)) {
+        if (!preg_match('/createApp\(.*?mount\(el\);/s', $content, $matches)) {
             throw new \Exception("Could not find createApp chain in {$this->appEntry}");
         }
 
@@ -104,17 +103,14 @@ class AddVuePlugin
             throw new \Exception('Could not parse createApp chain structure');
         }
 
-        $beforeMount = $matches[1];
+        $beforeMount = trim($matches[1]);
 
-        // Find the base indentation of the return statement
-        preg_match('/^(\s+)createApp/m', $content, $indentMatches);
+        // Find the base indentation of the mount function
+        preg_match('/^(\s+).mount\(/m', $content, $indentMatches);
         $baseIndent = $indentMatches[1] ?? '    ';
 
-        // Calculate the chain indentation (2 spaces more than the previous line)
-        $chainIndent = $baseIndent . '  ';
-
         // Add .use(fusion) with proper indentation
-        $modifiedChain = $beforeMount . "\n" . $chainIndent . '.use(fusion)' . "\n" . $chainIndent . '.mount(el);';
+        $modifiedChain = $beforeMount."\n".$baseIndent.'.use(fusion)'."\n".$baseIndent.'.mount(el);';
 
         return str_replace($createAppChain, $modifiedChain, $content);
     }

--- a/src/Console/Actions/AddVuePlugin.php
+++ b/src/Console/Actions/AddVuePlugin.php
@@ -15,6 +15,8 @@ class AddVuePlugin
 {
     use InteractsWithIO;
 
+    private ?string $appEntry;
+
     public function __construct(InputInterface $input, OutputInterface $output)
     {
         $this->input = $input;
@@ -23,26 +25,24 @@ class AddVuePlugin
 
     public function handle()
     {
-        $appPath = base_path('resources/js/app.js');
 
-        // Check if app.js exists
-        if (!File::exists($appPath)) {
-            $this->error('resources/js/app.js not found!');
-
+        if (!$this->findAppEntry()) {
             return 1;
         }
+
+        $appPath = base_path($this->appEntry);
 
         $content = File::get($appPath);
 
         // Check if fusion is already imported
         if (str_contains($content, '@fusion/vue/vue')) {
-            $this->info('[Vue] Fusion is already imported in app.js!');
+            $this->info("[Vue] Fusion is already imported in {$this->appEntry}!");
 
             return 0;
         }
 
         // Create backup only if we need to make changes
-        $backupPath = base_path('resources/js/app.js.backup');
+        $backupPath = base_path("{$this->appEntry}.backup");
         File::copy($appPath, $backupPath);
 
         try {
@@ -55,8 +55,8 @@ class AddVuePlugin
             // Write modified content back to file
             File::put($appPath, $content);
 
-            $this->info('[Vue] Successfully added Fusion to app.js');
-            $this->info('[Vue] Backup created at resources/js/app.js.backup');
+            $this->info("[Vue] Successfully added Fusion to {$this->appEntry}");
+            $this->info("[Vue] Backup created at {$this->appEntry}.backup");
 
             return 0;
         } catch (\Exception $e) {
@@ -77,7 +77,7 @@ class AddVuePlugin
         preg_match_all('/^import .+$/m', $content, $matches);
 
         if (empty($matches[0])) {
-            throw new \Exception('Could not find import statements in app.js');
+            throw new \Exception("Could not find import statements in {$this->appEntry}");
         }
 
         $lastImport = end($matches[0]);
@@ -93,8 +93,8 @@ class AddVuePlugin
     private function addFusionPlugin(string $content): string
     {
         // Find the createApp chain
-        if (!preg_match('/return createApp.*?mount\(el\);/s', $content, $matches)) {
-            throw new \Exception('Could not find createApp chain in app.js');
+        if (!preg_match('/createApp.*?mount\(el\);/s', $content, $matches)) {
+            throw new \Exception("Could not find createApp chain in {$this->appEntry}");
         }
 
         $createAppChain = $matches[0];
@@ -107,7 +107,7 @@ class AddVuePlugin
         $beforeMount = $matches[1];
 
         // Find the base indentation of the return statement
-        preg_match('/^(\s+)return createApp/m', $content, $indentMatches);
+        preg_match('/^(\s+)createApp/m', $content, $indentMatches);
         $baseIndent = $indentMatches[1] ?? '    ';
 
         // Calculate the chain indentation (2 spaces more than the previous line)
@@ -117,5 +117,21 @@ class AddVuePlugin
         $modifiedChain = $beforeMount . "\n" . $chainIndent . '.use(fusion)' . "\n" . $chainIndent . '.mount(el);';
 
         return str_replace($createAppChain, $modifiedChain, $content);
+    }
+
+    private function findAppEntry(): bool
+    {
+        $this->appEntry = collect(['resources/js/app.js', 'resources/js/app.ts'])
+            ->filter(fn(string $configName) => File::exists(base_path($configName)))
+            ->first();
+
+        // Check if app.[js/ts] exists
+        if (!$this->appEntry) {
+            $this->error('[Vite] resources/js/app.[js/ts] not found!');
+
+            return false;
+        }
+
+        return true;
     }
 }

--- a/tests/Unit/Console/Actions/AddVuePluginTest.php
+++ b/tests/Unit/Console/Actions/AddVuePluginTest.php
@@ -1,0 +1,218 @@
+<?php
+
+namespace Fusion\Tests\Unit\Console\Actions;
+
+use Fusion\Console\Actions\AddVuePlugin;
+use Fusion\Tests\Unit\Base;
+use Illuminate\Support\Facades\File;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\NullOutput;
+
+
+
+class AddVuePluginTest extends Base
+{
+
+    private AddVuePlugin $action;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        app()->setBasePath(__DIR__ . '/__test');
+
+        File::ensureDirectoryExists(__DIR__ . '/__test/resources/js');
+        File::put(base_path('resources/js/app.js'), $this->appJsOriginalString());
+
+        $this->action = app()->make(AddVuePlugin::class, [
+            'input' => new ArrayInput([]),
+            'output' => new NullOutput,
+        ]);
+    }
+
+    protected function tearDown(): void
+    {
+        File::deleteDirectory(__DIR__ . '/__test');
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function can_add_fusion_plugin_to_app_entry()
+    {
+        $status = $this->action->handle();
+
+        $this->assertNotEquals(1, $status);
+        $this->assertEquals(File::get(base_path('resources/js/app.js')), $this->appJsExpectedString());
+        $this->assertEquals(File::get(base_path('resources/js/app.js.backup')), $this->appJsOriginalString());
+    }
+
+    #[Test]
+    public function can_add_fusion_plugin_to_app_ts_entry()
+    {
+        File::delete(base_path('resources/js/app.js'));
+        File::put(base_path('resources/js/app.ts'), $this->appTsOriginalString());
+
+        $status = $this->action->handle();
+
+        $this->assertNotEquals(1, $status);
+        $this->assertEquals(File::get(base_path('resources/js/app.ts')), $this->appTsExpectedString());
+        $this->assertEquals(File::get(base_path('resources/js/app.ts.backup')), $this->appTsOriginalString());
+    }
+
+    private function appTsExpectedString(): string
+    {
+        return "import '../css/app.css';
+
+import { createInertiaApp } from '@inertiajs/vue3';
+import { resolvePageComponent } from 'laravel-vite-plugin/inertia-helpers';
+import type { DefineComponent } from 'vue';
+import { createApp, h } from 'vue';
+import { ZiggyVue } from 'ziggy-js';
+import { initializeTheme } from './composables/useAppearance';
+import fusion from '@fusion/vue/vue';
+
+// Extend ImportMeta interface for Vite...
+declare module 'vite/client' {
+    interface ImportMetaEnv {
+        readonly VITE_APP_NAME: string;
+        [key: string]: string | boolean | undefined;
+    }
+
+    interface ImportMeta {
+        readonly env: ImportMetaEnv;
+        readonly glob: <T>(pattern: string) => Record<string, () => Promise<T>>;
+    }
+}
+
+const appName = import.meta.env.VITE_APP_NAME || 'Laravel';
+
+createInertiaApp({
+    title: (title) => `\${title} - \${appName}`,
+    resolve: (name) => resolvePageComponent(`./pages/\${name}.vue`, import.meta.glob<DefineComponent>('./pages/**/*.vue')),
+    setup({ el, App, props, plugin }) {
+        createApp({ render: () => h(App, props) })
+            .use(plugin)
+            .use(ZiggyVue)
+            
+          .use(fusion)
+          .mount(el);
+    },
+    progress: {
+        color: '#4B5563',
+    },
+});
+
+// This will set light / dark mode on page load...
+initializeTheme();
+";
+    }
+
+    private function appJsExpectedString(): string
+    {
+        return "import '../css/app.css';
+import './bootstrap';
+
+import {createInertiaApp} from '@inertiajs/vue3';
+import {resolvePageComponent} from 'laravel-vite-plugin/inertia-helpers';
+import {createApp, h} from 'vue';
+import fusion from '@fusion/vue/vue';
+
+const appName = import.meta.env.VITE_APP_NAME || 'Laravel';
+
+createInertiaApp({
+  title: (title) => `\${title} - \${appName}`,
+  resolve: (name) =>
+    resolvePageComponent(
+      `./Pages/\${name}.vue`,
+      import.meta.glob('./Pages/**/*.vue'),
+    ),
+  setup({el, App, props, plugin}) {
+    return createApp({render: () => h(App, props)})
+      .use(plugin)
+      
+      .use(fusion)
+      .mount(el);
+  },
+  progress: {
+    color: '#4B5563',
+  },
+});
+";
+    }
+
+    private function appJsOriginalString(): string
+    {
+        return "import '../css/app.css';
+import './bootstrap';
+
+import {createInertiaApp} from '@inertiajs/vue3';
+import {resolvePageComponent} from 'laravel-vite-plugin/inertia-helpers';
+import {createApp, h} from 'vue';
+
+const appName = import.meta.env.VITE_APP_NAME || 'Laravel';
+
+createInertiaApp({
+  title: (title) => `\${title} - \${appName}`,
+  resolve: (name) =>
+    resolvePageComponent(
+      `./Pages/\${name}.vue`,
+      import.meta.glob('./Pages/**/*.vue'),
+    ),
+  setup({el, App, props, plugin}) {
+    return createApp({render: () => h(App, props)})
+      .use(plugin)
+      .mount(el);
+  },
+  progress: {
+    color: '#4B5563',
+  },
+});
+";
+    }
+
+    private function appTsOriginalString(): string
+    {
+        return "import '../css/app.css';
+
+import { createInertiaApp } from '@inertiajs/vue3';
+import { resolvePageComponent } from 'laravel-vite-plugin/inertia-helpers';
+import type { DefineComponent } from 'vue';
+import { createApp, h } from 'vue';
+import { ZiggyVue } from 'ziggy-js';
+import { initializeTheme } from './composables/useAppearance';
+
+// Extend ImportMeta interface for Vite...
+declare module 'vite/client' {
+    interface ImportMetaEnv {
+        readonly VITE_APP_NAME: string;
+        [key: string]: string | boolean | undefined;
+    }
+
+    interface ImportMeta {
+        readonly env: ImportMetaEnv;
+        readonly glob: <T>(pattern: string) => Record<string, () => Promise<T>>;
+    }
+}
+
+const appName = import.meta.env.VITE_APP_NAME || 'Laravel';
+
+createInertiaApp({
+    title: (title) => `\${title} - \${appName}`,
+    resolve: (name) => resolvePageComponent(`./pages/\${name}.vue`, import.meta.glob<DefineComponent>('./pages/**/*.vue')),
+    setup({ el, App, props, plugin }) {
+        createApp({ render: () => h(App, props) })
+            .use(plugin)
+            .use(ZiggyVue)
+            .mount(el);
+    },
+    progress: {
+        color: '#4B5563',
+    },
+});
+
+// This will set light / dark mode on page load...
+initializeTheme();
+";
+    }
+
+}

--- a/tests/Unit/Console/Actions/AddVuePluginTest.php
+++ b/tests/Unit/Console/Actions/AddVuePluginTest.php
@@ -93,9 +93,8 @@ createInertiaApp({
         createApp({ render: () => h(App, props) })
             .use(plugin)
             .use(ZiggyVue)
-            
-          .use(fusion)
-          .mount(el);
+            .use(fusion)
+            .mount(el);
     },
     progress: {
         color: '#4B5563',
@@ -129,7 +128,6 @@ createInertiaApp({
   setup({el, App, props, plugin}) {
     return createApp({render: () => h(App, props)})
       .use(plugin)
-      
       .use(fusion)
       .mount(el);
   },

--- a/tests/Unit/Console/Actions/AddVuePluginTest.php
+++ b/tests/Unit/Console/Actions/AddVuePluginTest.php
@@ -9,11 +9,8 @@ use PHPUnit\Framework\Attributes\Test;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\NullOutput;
 
-
-
 class AddVuePluginTest extends Base
 {
-
     private AddVuePlugin $action;
 
     protected function setUp(): void
@@ -214,5 +211,4 @@ createInertiaApp({
 initializeTheme();
 ";
     }
-
 }


### PR DESCRIPTION
## Issue
The install command searches for a app.js but with a new Laravel install comes a app.ts. This Throws an error and the plugin is not added to the vue mount.

## Solution
I updated the install command to check if an .js or .ts app exists. Also i changed the 
`/return createApp.*?mount\(el\);/s` regex to `/createApp.*?mount\(el\);/s` because in the Inertia docs and the new Laravel Installation the `return` isn't present and the command would not work with.

## Test
I saw that there are no Tests for the Commands, or i didn't found them. I added one Test Class for the AddVuePlugin Console Action but limited my self to only testing the happy path and my new Addition to keep the PR small. The Test it self is a bit hacky but should work. I would be happy if someone has a more elegant Solution.
